### PR TITLE
pass arguments to executing source differently

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -85,13 +85,13 @@ const run = async () => {
 					core.info(`executing file ${ source } to generate ${ dest }`)
 					mkdirSync(dirname(dest), { recursive: true })
 					const executeArgs = Object.entries(file.executeArguments).reduce(
-						(accumulator, [ key, value ]) => `${ accumulator } ${ key.replace(/[^a-z0-9_-]/gi, '') }='${ value }'`,
+						(accumulator, [ key, value ]) => `${ accumulator }${ key.replace(/[^a-z0-9_-]/gi, '') }='${ value.replace(/'/g, "'\"'\"'") }' `,
 						''
-					).trim()
+					)
 					if (executeArgs) {
 						core.info(`passing arguments ${ executeArgs }`)
 					}
-					const executeOutput = await execCmd(`./${ source } ${ executeArgs }`)
+					const executeOutput = await execCmd(`${ executeArgs }./${ source }`)
 					writeFileSync(dest, `${ executeOutput }\n`)
 				} else {
 					const deleteOrphaned = isDirectory && file.deleteOrphaned


### PR DESCRIPTION
instead of passing as arguments to the executable source (which i believe would be language dependent?), have the arguments passed in before call to executable source, e.g. `ARG_0=value_0 ARG_N=value_n ./executable-source.sh`, so they are able to be referenced within the executable source at start